### PR TITLE
Migrate from `flake8` to `ruff`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
           name: Run tests
           command: pytest
 
-  flake:
+  ruff:
     parameters:
       version:
         description: "version tag"
@@ -65,8 +65,8 @@ jobs:
           # app-dir: ~/project/package-directory/  # If you're requirements.txt isn't in the root directory.
           pip-dependency-file: requirements_dev.txt
       - run:
-          name: Flake8
-          command: flake8 tests
+          name: Ruff
+          command: ruff tests
 
 
   test_documentation_build:
@@ -110,7 +110,7 @@ workflows:
                 - "3.10"
                 - "3.11"
                 - "3.12"
-      - flake:
+      - ruff:
           matrix:
             parameters:
               version:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -100,13 +100,13 @@ development. Please note this documentation assumes you already have
 
 ::
 
-5. When you're done making changes, check that your changes pass flake8. Since,
-   this package contains mostly templates the flake should be run for tests
+5. When you're done making changes, check that your changes pass ruff. Since,
+   this package contains mostly templates the ruff should be run for tests
    directory:
 
    .. code-block:: bash
 
-        $ flake8 ./tests
+        $ ruff ./tests
 
 ::
 
@@ -136,7 +136,7 @@ development. Please note this documentation assumes you already have
 
         $ tox
 
-   If you are missing flake8, pytest and/or tox, just `pip install` them into
+   If you are missing ruff, pytest and/or tox, just `pip install` them into
    your virtualenv.
 
 ::

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Features
 --------
 
 * Testing setup with ``unittest`` and ``python setup.py test`` or ``pytest``
-* Circleci_: Ready for Circleci Continuous Integration testing, flake8 and deployment
+* Circleci_: Ready for Circleci Continuous Integration testing, ruff and deployment
 * Sphinx_ docs: Documentation ready for generation with, for example, `Read the Docs`_
 * bump2version_: Pre-configured version bumping with a single command
 * Auto-release to PyPI_ when you push a new tag to master (optional)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,5 +3,5 @@ cookiecutter
 pytest-cookies
 alabaster
 watchdog
-flake8
+ruff
 sphinx

--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
           name: Run tests
           command: pytest
 
-  flake:
+  ruff:
     parameters:
       version:
         description: "version tag"
@@ -65,8 +65,8 @@ jobs:
           # app-dir: ~/project/package-directory/  # If you're requirements.txt isn't in the root directory.
           pip-dependency-file: requirements_dev.txt
       - run:
-          name: Flake8
-          command: flake8 {{ cookiecutter.project_slug }} tests
+          name: Ruff
+          command: ruff {{ cookiecutter.project_slug }} tests
 
 
   test_documentation_build:
@@ -133,7 +133,7 @@ workflows:
               {% for extension, details in cookiecutter._valid_versions|dictsort %}{% if extension == cookiecutter.minimum_python_version -%}{% for app in details.version_list -%}
                 - "{{ app }}"
               {% endfor -%}{% endif %}{% endfor %}
-      - flake:
+      - ruff:
           matrix:
             parameters:
               version:
@@ -170,7 +170,7 @@ workflows:
             tags:
               only: /^v[0-9]+(\.[0-9]+)*$/
 
-      - flake:
+      - ruff:
           matrix:
             parameters:
               version:
@@ -205,7 +205,7 @@ workflows:
                 - "{{ cookiecutter.default_python_version }}"
           requires:
             - build_and_test
-            - flake
+            - ruff
             - test_documentation_build
           filters:
             branches:

--- a/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.project_slug}}/CONTRIBUTING.rst
@@ -55,14 +55,13 @@ Ready to contribute? Here's how to set up `{{ cookiecutter.project_slug }}` for 
 
    Now you can make your changes locally.
 
-5. When you're done making changes, check that your changes pass flake8 and the
+5. When you're done making changes, check that your changes pass ruff and the
    tests::
 
-    $ flake8 {{ cookiecutter.project_slug }} tests
+    $ ruff pyfar tests
     $ pytest
 
-   flake8 test must pass without any warnings for `./{{ cookiecutter.project_slug }}` and `./tests` using the default or a stricter configuration. Flake8 ignores `E123/E133, E226` and `E241/E242` by default. If necessary adjust your flake8 and linting configuration in your IDE accordingly.
-
+   ruff must pass without any warnings for `./{{ cookiecutter.project_slug }}` and `./tests` using the default or a stricter configuration. Ruff ignores a couple of PEP Errors (see `./pyproject.toml`). If necessary, adjust your linting configuration in your IDE accordingly.
 6. Commit your changes and push your branch to {% if rwth %}GitLab{% elif github %}GitHub{% endif %}::
 
     $ git add .

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.ruff]
+exclude = [
+    ".git",
+    "docs",
+]
+ignore = []
+select = [
+    "E",
+    "F",
+    "W",
+]

--- a/{{cookiecutter.project_slug}}/requirements_dev.txt
+++ b/{{cookiecutter.project_slug}}/requirements_dev.txt
@@ -2,7 +2,7 @@ pip
 bump2version
 wheel
 watchdog
-flake8
+ruff==0.4.1
 coverage
 Sphinx
 twine

--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -14,8 +14,6 @@ replace = __version__ = '{new_version}'
 [bdist_wheel]
 universal = 1
 
-[flake8]
-exclude = .git, docs
 
 {%- if cookiecutter.use_pytest == 'y' %}
 [aliases]

--- a/{{cookiecutter.project_slug}}/setup.py
+++ b/{{cookiecutter.project_slug}}/setup.py
@@ -27,7 +27,7 @@ test_requirements = [
     'bump2version',
     'wheel',
     'watchdog',
-    'flake8',
+    'ruff',
     'coverage',
     'Sphinx',
     'twine',


### PR DESCRIPTION
closes #23

- replace flake8 by ruff in project and also in this cookiecutter repo