### PR TITLE
Doc: cleanup and fix auto header generation

### DIFF
--- a/tests/reference/docs/conf.py
+++ b/tests/reference/docs/conf.py
@@ -174,24 +174,34 @@ if not os.path.exists(html_logo):
     shutil.copyfile(
         'resources/logos/pyfar_logos_fixed_size_pyfar.png', html_logo)
 
+
 # replace imkar hard link to internal link
 with open("_static/header.rst", "rt") as fin:
+    # collect lines in a list
+    lines = [line for line in fin]
+    
+    # find line where pyfar package is mentioned, to determine the start of 
+    # the packages list in the header
+    n_line_pyfar = 0
+    for i, line in enumerate(lines):
+        if 'https://pyfar.readthedocs.io' in line:
+            # remove the 4 lines at the top, which do not include items
+            n_line_pyfar = i - 4
+            break
+
+    # replace readthedocs link with internal link to this documentation
+    lines_mod = [
+        line.replace(f'https://{project}.readthedocs.io', project) for line in lines]
+    
+    # add this documentation link to the end of the list, so that it is in the
+    # doc tree
+    contains_project = any(project in line for line in lines_mod)
+    lines_mod.append(f'   {project} <{project}>\n')
+
     with open("header.rst", "wt") as fout:
-        lines = [line.replace(f'https://{project}.readthedocs.io', project) for line in fin]
-        contains_project = any(project in line for line in lines)
+        fout.writelines(lines_mod)
 
-        fout.writelines(lines)
-
-        # add project to the list of projects if not in header
-        if not contains_project:
-            fout.write(f'   {project} <{project}>\n')
-        
-        # count the number of gallery headings
-        count_gallery_headings = np.sum(
-            ['https://pyfar-gallery.readthedocs.io' in line for line in lines])
-
-
-# set dropdown header after gallery headings
-html_theme_options['header_links_before_dropdown'] = count_gallery_headings+1
+# set dropdown header at pyfar appearance
+html_theme_options['header_links_before_dropdown'] = n_line_pyfar
 
 

--- a/tests/reference/docs/conf.py
+++ b/tests/reference/docs/conf.py
@@ -196,7 +196,8 @@ with open("_static/header.rst", "rt") as fin:
     # add this documentation link to the end of the list, so that it is in the
     # doc tree
     contains_project = any(project in line for line in lines_mod)
-    lines_mod.append(f'   {project} <{project}>\n')
+    if not contains_project:
+        lines_mod.append(f'   {project} <{project}>\n')
 
     with open("header.rst", "wt") as fout:
         fout.writelines(lines_mod)

--- a/tests/reference/docs/conf.py
+++ b/tests/reference/docs/conf.py
@@ -217,7 +217,7 @@ n_toctree_pyfar = n_line_pyfar - 4
 if n_toctree_pyfar < 1:	
     raise ValueError(
         "Could not find the line where pyfar package is mentioned. "
-        "Please check the header.rst file."
+        "Please check the header.rst file in the gallery."
     )
 
 # set dropdown header at pyfar appearance, so that pyfar is the first item in

--- a/tests/reference/docs/conf.py
+++ b/tests/reference/docs/conf.py
@@ -175,40 +175,51 @@ if not os.path.exists(html_logo):
         'resources/logos/pyfar_logos_fixed_size_pyfar.png', html_logo)
 
 
-# replace imkar hard link to internal link
+# -- modify downloaded header file from the gallery to   ----------------------
+# -- aline with the local toctree ---------------------------------------------
+
+# read the header file from the gallery
 with open("_static/header.rst", "rt") as fin:
-    # collect lines in a list
     lines = [line for line in fin]
-    
-    # find line where pyfar package is mentioned, to determine the start of 
-    # the packages list in the header
-    n_line_pyfar = 0
-    for i, line in enumerate(lines):
-        if 'https://pyfar.readthedocs.io' in line:
-            # remove the 4 lines at the top, which do not include items
-            n_line_pyfar = i - 4
-            break
 
-    if n_line_pyfar < 1:	
-        raise ValueError(
-            "Could not find the line where pyfar package is mentioned. "
-            "Please check the header.rst file."
-        )
-    
-    # replace readthedocs link with internal link to this documentation
-    lines_mod = [
-        line.replace(f'https://{project}.readthedocs.io', project) for line in lines]
-    
-    # add this documentation link to the end of the list, so that it is in the
-    # doc tree
-    contains_project = any(project in line for line in lines_mod)
-    if not contains_project:
-        lines_mod.append(f'   {project} <{project}>\n')
+# replace readthedocs link with internal link to this documentation
+lines_mod = [
+    line.replace(f'https://{project}.readthedocs.io', project) for line in lines]
 
-    with open("header.rst", "wt") as fout:
-        fout.writelines(lines_mod)
+# if not found, add this documentation link to the end of the list, so that
+# it is in the doc tree
+contains_project = any(project in line for line in lines_mod)
+if not contains_project:
+    lines_mod.append(f'   {project} <{project}>\n')
 
-# set dropdown header at pyfar appearance
-html_theme_options['header_links_before_dropdown'] = n_line_pyfar
+# write the modified header file
+# to the doc\header.rst folder, so that it can be used in the documentation
+with open("header.rst", "wt") as fout:
+    fout.writelines(lines_mod)
 
 
+# -- find position of pyfar package in toctree --------------------------------
+# -- this is required to define the dropdown of Packages in the header --------
+
+# find line where pyfar package is mentioned, to determine the start of 
+# the packages list in the header
+n_line_pyfar = 0
+for i, line in enumerate(lines):
+    if 'https://pyfar.readthedocs.io' in line:
+        n_line_pyfar = i
+        break
+
+# the first 4 lines of the header file are defining the settings and a empty
+# line of the toctree, therefore we need to subtract 4 from the line number
+# of the pyfar package to get the correct position in the toctree
+n_toctree_pyfar = n_line_pyfar - 4
+
+if n_toctree_pyfar < 1:	
+    raise ValueError(
+        "Could not find the line where pyfar package is mentioned. "
+        "Please check the header.rst file."
+    )
+
+# set dropdown header at pyfar appearance, so that pyfar is the first item in
+# the dropdown called Packages
+html_theme_options['header_links_before_dropdown'] = n_toctree_pyfar

--- a/tests/reference/docs/conf.py
+++ b/tests/reference/docs/conf.py
@@ -189,6 +189,12 @@ with open("_static/header.rst", "rt") as fin:
             n_line_pyfar = i - 4
             break
 
+    if n_line_pyfar < 1:	
+        raise ValueError(
+            "Could not find the line where pyfar package is mentioned. "
+            "Please check the header.rst file."
+        )
+    
     # replace readthedocs link with internal link to this documentation
     lines_mod = [
         line.replace(f'https://{project}.readthedocs.io', project) for line in lines]

--- a/{{cookiecutter.project_slug}}/docs/conf.py
+++ b/{{cookiecutter.project_slug}}/docs/conf.py
@@ -191,6 +191,12 @@ with open("_static/header.rst", "rt") as fin:
             # remove the 4 lines at the top, which do not include items
             n_line_pyfar = i - 4
             break
+    
+    if n_line_pyfar < 1:	
+        raise ValueError(
+            "Could not find the line where pyfar package is mentioned. "
+            "Please check the header.rst file."
+        )
 
     # replace readthedocs link with internal link to this documentation
     lines_mod = [

--- a/{{cookiecutter.project_slug}}/docs/conf.py
+++ b/{{cookiecutter.project_slug}}/docs/conf.py
@@ -178,40 +178,51 @@ if not os.path.exists(html_logo):
         'resources/logos/pyfar_logos_fixed_size_pyfar.png', html_logo)
 
 
-# replace {{ cookiecutter.project_slug }} hard link to internal link
+# -- modify downloaded header file from the gallery to   ----------------------
+# -- aline with the local toctree ---------------------------------------------
+
+# read the header file from the gallery
 with open("_static/header.rst", "rt") as fin:
-    # collect lines in a list
     lines = [line for line in fin]
-    
-    # find line where pyfar package is mentioned, to determine the start of 
-    # the packages list in the header
-    n_line_pyfar = 0
-    for i, line in enumerate(lines):
-        if 'https://pyfar.readthedocs.io' in line:
-            # remove the 4 lines at the top, which do not include items
-            n_line_pyfar = i - 4
-            break
-    
-    if n_line_pyfar < 1:	
-        raise ValueError(
-            "Could not find the line where pyfar package is mentioned. "
-            "Please check the header.rst file."
-        )
 
-    # replace readthedocs link with internal link to this documentation
-    lines_mod = [
-        line.replace(f'https://{project}.readthedocs.io', project) for line in lines]
-    
-    # add this documentation link to the end of the list, so that it is in the
-    # doc tree
-    contains_project = any(project in line for line in lines_mod)
-    if not contains_project:
-        lines_mod.append(f'   {project} <{project}>\n')
+# replace readthedocs link with internal link to this documentation
+lines_mod = [
+    line.replace(f'https://{project}.readthedocs.io', project) for line in lines]
 
-    with open("header.rst", "wt") as fout:
-        fout.writelines(lines_mod)
+# if not found, add this documentation link to the end of the list, so that
+# it is in the doc tree
+contains_project = any(project in line for line in lines_mod)
+if not contains_project:
+    lines_mod.append(f'   {project} <{project}>\n')
 
-# set dropdown header at pyfar appearance
-html_theme_options['header_links_before_dropdown'] = n_line_pyfar
+# write the modified header file
+# to the doc\header.rst folder, so that it can be used in the documentation
+with open("header.rst", "wt") as fout:
+    fout.writelines(lines_mod)
 
 
+# -- find position of pyfar package in toctree --------------------------------
+# -- this is required to define the dropdown of Packages in the header --------
+
+# find line where pyfar package is mentioned, to determine the start of 
+# the packages list in the header
+n_line_pyfar = 0
+for i, line in enumerate(lines):
+    if 'https://pyfar.readthedocs.io' in line:
+        n_line_pyfar = i
+        break
+
+# the first 4 lines of the header file are defining the settings and a empty
+# line of the toctree, therefore we need to subtract 4 from the line number
+# of the pyfar package to get the correct position in the toctree
+n_toctree_pyfar = n_line_pyfar - 4
+
+if n_toctree_pyfar < 1:	
+    raise ValueError(
+        "Could not find the line where pyfar package is mentioned. "
+        "Please check the header.rst file in the gallery."
+    )
+
+# set dropdown header at pyfar appearance, so that pyfar is the first item in
+# the dropdown called Packages
+html_theme_options['header_links_before_dropdown'] = n_toctree_pyfar

--- a/{{cookiecutter.project_slug}}/docs/conf.py
+++ b/{{cookiecutter.project_slug}}/docs/conf.py
@@ -177,24 +177,34 @@ if not os.path.exists(html_logo):
     shutil.copyfile(
         'resources/logos/pyfar_logos_fixed_size_pyfar.png', html_logo)
 
+
 # replace {{ cookiecutter.project_slug }} hard link to internal link
 with open("_static/header.rst", "rt") as fin:
+    # collect lines in a list
+    lines = [line for line in fin]
+    
+    # find line where pyfar package is mentioned, to determine the start of 
+    # the packages list in the header
+    n_line_pyfar = 0
+    for i, line in enumerate(lines):
+        if 'https://pyfar.readthedocs.io' in line:
+            # remove the 4 lines at the top, which do not include items
+            n_line_pyfar = i - 4
+            break
+
+    # replace readthedocs link with internal link to this documentation
+    lines_mod = [
+        line.replace(f'https://{project}.readthedocs.io', project) for line in lines]
+    
+    # add this documentation link to the end of the list, so that it is in the
+    # doc tree
+    contains_project = any(project in line for line in lines_mod)
+    lines_mod.append(f'   {project} <{project}>\n')
+
     with open("header.rst", "wt") as fout:
-        lines = [line.replace(f'https://{project}.readthedocs.io', project) for line in fin]
-        contains_project = any(project in line for line in lines)
+        fout.writelines(lines_mod)
 
-        fout.writelines(lines)
-
-        # add project to the list of projects if not in header
-        if not contains_project:
-            fout.write(f'   {project} <{project}>\n')
-        
-        # count the number of gallery headings
-        count_gallery_headings = np.sum(
-            ['https://pyfar-gallery.readthedocs.io' in line for line in lines])
-
-
-# set dropdown header after gallery headings
-html_theme_options['header_links_before_dropdown'] = count_gallery_headings+1
+# set dropdown header at pyfar appearance
+html_theme_options['header_links_before_dropdown'] = n_line_pyfar
 
 

--- a/{{cookiecutter.project_slug}}/docs/conf.py
+++ b/{{cookiecutter.project_slug}}/docs/conf.py
@@ -199,7 +199,8 @@ with open("_static/header.rst", "rt") as fin:
     # add this documentation link to the end of the list, so that it is in the
     # doc tree
     contains_project = any(project in line for line in lines_mod)
-    lines_mod.append(f'   {project} <{project}>\n')
+    if not contains_project:
+        lines_mod.append(f'   {project} <{project}>\n')
 
     with open("header.rst", "wt") as fout:
         fout.writelines(lines_mod)


### PR DESCRIPTION
### Problem:
in all packages the header will be automatically created based on the header file in the gallery. 
Also the dropdown named Packages is automatically calcualted at the moment. currently the number of ``https://pyfar-gallery.readthedocs.io`` are counted, which would fail if https://github.com/pyfar/gallery/issues/104 is introduced

### Changes proposed in this pull request:

- cleanup postprocessing of the header automatic maipulation
- now we look for the ``https://pyfar.readthedocs.io``, assuming that pyfar is always the first package and determining ``header_links_before_dropdown`` based on it
