### PR TITLE
Fix: went to Tutorial

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,7 +3,7 @@
   "email": "",
   "git_service": ["https://github.com", "https://git.rwth-aachen.de"],
   "git_username": "pyfar",
-  "project_name": "Your Python Project",
+  "project_name": "mypackage",
   "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
   "project_short_description": "Python Boilerplate contains all the boilerplate you need to create a Python package.",
   "project_long_description": "{{ cookiecutter.project_short_description }}",

--- a/docs/prompts.rst
+++ b/docs/prompts.rst
@@ -26,7 +26,7 @@ project_name
     The name of your new Python package project. This is used in documentation, so spaces and any characters are fine here.
 
 project_slug
-    The namespace of your Python package. This should be Python import-friendly. Typically, it is the slugified version of project_name. Note: your PyPi project and Travis links will use project_slug, so change those in the README afterwards.
+    The namespace of your Python package. This should be Python import-friendly. Typically, it is the slugified version of project_name. Note: your PyPi project and CircleCI links will use project_slug, so change those in the README afterwards.
 
 project_short_description
     A 1-sentence description of what your Python package does.
@@ -44,6 +44,9 @@ Options
 -------
 
 The following package configuration options set up different features for your project.
+
+logo_path_gallery
+    The path to the logo image within the pyfar gallery docs repository https://github.com/pyfar/gallery/tree/main/docs. If left empty, the standard pyfar logo will be used.
 
 use_circle_ci
     Whether to use `CircleCI <https://circleci.com/>`_.
@@ -77,7 +80,7 @@ use_pypi_deployment_with_ci
     Whether to use PyPI deployment with `CircleCI <https://circleci.com/>`_.
 
 add_pyup_badge
-    Whether to include a `pyup <https://github.com/pyupio/pyup>`_ badge
+    Whether to include a `pyup <https://github.com/pyupio/pyup>`_ badge.
 
 minimum_python_version
     The minimum Python version required to run the package.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -94,7 +94,7 @@ Step 5: Set Up Circle Ci
 
 Login using your Github credentials. It may take a few minutes for CircleCi to load up a list of all your GitHub repos. They in the Projects environment.
 
-Add the public repo to your CircleCI account by clicking ``Set Up Project`` next to the ``mypackage`` repo. Choose the ``.circleci/config.yml`` file and the ``main`` brach and click ``Set Up Project``. No need to do further settings.
+Add the public repo to your CircleCI account by clicking ``Set Up Project`` next to the ``mypackage`` repo. Choose the ``.circleci/config.yml`` file and the ``main`` branch and click ``Set Up Project``. No need to do further settings.
 
 You can now push to your GitHub repo and CircleCI will automatically run the tests. You can see the status of your tests in the CircleCI dashboard and on Github.
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -63,6 +63,7 @@ You will find one folder named after the ``[project_slug]``. Move into this fold
     git init .
     git add .
     git commit -m "Initial skeleton."
+    git branch -M main
     git remote add origin git@github.com:myusername/mypackage.git
     git push -u origin main
 
@@ -93,7 +94,7 @@ Step 5: Set Up Circle Ci
 
 Login using your Github credentials. It may take a few minutes for CircleCi to load up a list of all your GitHub repos. They in the Projects environment.
 
-Add the public repo to your CircleCI account by clicking ``Set Up Project`` next to the ``mypackage`` repo. Choose the ``.circleci/config.yml`` file and click ``Set Up Project``. No need to do further settings.
+Add the public repo to your CircleCI account by clicking ``Set Up Project`` next to the ``mypackage`` repo. Choose the ``.circleci/config.yml`` file and the ``main`` brach and click ``Set Up Project``. No need to do further settings.
 
 You can now push to your GitHub repo and CircleCI will automatically run the tests. You can see the status of your tests in the CircleCI dashboard and on Github.
 
@@ -105,7 +106,7 @@ Step 6: Set Up Read the Docs
 
 `Read the Docs`_ hosts documentation for the open source community. Think of it as Continuous Documentation.
 
-Log into your account at `Read the Docs`_ . If you don't have one, create one and log into it. Connect your GitHub account to your Read the Docs account.
+Log into your account at `Read the Docs`_. If you don't have one, create one and log into it via your GitHub account. Connect your GitHub account to your Read the Docs account.
 Click on the ``Add project`` button. You should find your project ``mypackage`` repo listed. Use the ``Continue`` button to import the project via using the automatic configuration. It is already setup in your Github repository with the ``.readthedocs.yaml`` file.
 
 .. _`Read the Docs`: https://readthedocs.org/

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,7 +1,6 @@
 import re
 import sys
 
-from packaging import version
 
 MODULE_REGEX = r'^[_a-zA-Z][_a-zA-Z0-9]+$'
 module_name = '{{ cookiecutter.project_slug}}'
@@ -25,13 +24,6 @@ MODULE_REGEX = '3.[0-9]+'
 minimum_python_version = '{{ cookiecutter.minimum_python_version }}'
 if not re.match(MODULE_REGEX, minimum_python_version):
     print(f'ERROR: The project slug ({minimum_python_version}) is not a valid Python version number. Please use python 3.x')
-
-    #Exit to cancel project
-    sys.exit(1)
-
-
-if version.parse(default_python_version) < version.parse(minimum_python_version):
-    print(f'ERROR: The default python version ({default_python_version}) is not greater or equal than the minimum python version ({minimum_python_version}). Please use a default python version greater or equal than the minimum python version')
 
     #Exit to cancel project
     sys.exit(1)

--- a/tests/reference/docs/conf.py
+++ b/tests/reference/docs/conf.py
@@ -58,6 +58,7 @@ master_doc = 'index'
 project = 'imkar'
 copyright = "2025, The pyfar developers"
 author = "The pyfar developers"
+project_slug = "imkar"
 
 # The version info for the project you're documenting, acts as replacement
 # for |version| and |release|, also used in various other places throughout
@@ -186,13 +187,13 @@ with open("_static/header.rst", "rt") as fin:
 
 # replace readthedocs link with internal link to this documentation
 lines_mod = [
-    line.replace(f'https://{project}.readthedocs.io', project) for line in lines]
+    line.replace(f'https://{project_slug}.readthedocs.io', project_slug) for line in lines]
 
 # if not found, add this documentation link to the end of the list, so that
 # it is in the doc tree
-contains_project = any(project in line for line in lines_mod)
+contains_project = any(project_slug in line for line in lines_mod)
 if not contains_project:
-    lines_mod.append(f'   {project} <{project}>\n')
+    lines_mod.append(f'   {project} <{project_slug}>\n')
 
 # write the modified header file
 # to the doc\header.rst folder, so that it can be used in the documentation

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -80,7 +80,7 @@ def test_bake_with_defaults(cookies):
         found_toplevel_files = [
             f for f in os.listdir(result.project_path)]
         assert 'pyproject.toml' in found_toplevel_files
-        assert 'your_python_project' in found_toplevel_files
+        assert 'mypackage' in found_toplevel_files
         assert 'tests' in found_toplevel_files
 
 
@@ -289,7 +289,7 @@ def test_bake_gitignore_with_paths(cookies):
             result.project_path, '.gitignore'), 'r')
         assert len(re.findall(
             "\ndocs/resources/logos/"
-            "pyfar_logos_fixed_size_your_python_project.png\n",
+            "pyfar_logos_fixed_size_mypackage.png\n",
             file.read())) == 1
 
 
@@ -299,9 +299,9 @@ def test_bake_doc_settings(cookies):
         assert result.exit_code == 0
         assert result.exception is None
 
-        # test for incident in docs/your_python_project.rst
+        # test for incident in docs/mypackage.rst
         file = open(os.path.join(
-            result.project_path, 'docs', 'your_python_project.rst'), 'r')
+            result.project_path, 'docs', 'mypackage.rst'), 'r')
         assert len(re.findall(
             "Getting Started",
             file.read())) == 1
@@ -321,7 +321,7 @@ def test_bake_doc_settings(cookies):
             "\n    'sphinx_reredirects',\n",
             file_contend)) == 1
         assert len(re.findall(
-            "resources/logos/pyfar_logos_fixed_size_your_python_project.png",
+            "resources/logos/pyfar_logos_fixed_size_mypackage.png",
             file_contend)) == 2
 
 
@@ -364,7 +364,7 @@ def test_vs_pyfar_development(cookies, file):
         url = link + file
         pyfar_file = http.request("GET", url).data
 
-        # test for incident in docs/your_python_project.rst
+        # test for incident in docs/mypackage.rst
         file = open(os.path.join(
             result.project_path, file), 'r')
         # compare
@@ -398,7 +398,7 @@ def test_vs_reference_file(cookies, file):
             os.path.dirname(os.path.abspath(__file__)),
             'reference', file), 'r')
 
-        # test for incident in docs/your_python_project.rst
+        # test for incident in docs/mypackage.rst
         file_handle = open(os.path.join(
             result.project_path, file), 'r')
         # compare
@@ -423,7 +423,7 @@ def test_install_libsndfile1(cookies, install_libsndfile1):
         assert result.exit_code == 0
         assert result.exception is None
 
-        # test for incident in docs/your_python_project.rst
+        # test for incident in docs/mypackage.rst
         file_handle = open(os.path.join(
             result.project_path, '.circleci/config.yml'), 'r')
 
@@ -466,7 +466,7 @@ def test_doc_conf_vs_reference_file(cookies, file):
             'reference', file), 'r')
         print(result.project_path)
 
-        # test for incident in docs/your_python_project.rst
+        # test for incident in docs/mypackage.rst
         file_handle = open(os.path.join(
             result.project_path, file), 'r')
         print(result.project_path)

--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -120,4 +120,6 @@ docs/header.rst
 docs/_static/favicon.ico
 docs/_static/header.rst
 docs/_static/css/custom.css
+docs/_static/js/custom.js
+docs/resources/logos/pyfar_logos_fixed_size_pyfar.png
 docs/{{ cookiecutter.logo_path_gallery }}

--- a/{{cookiecutter.project_slug}}/docs/conf.py
+++ b/{{cookiecutter.project_slug}}/docs/conf.py
@@ -58,6 +58,7 @@ master_doc = 'index'
 project = '{{ cookiecutter.project_name }}'
 copyright = "{% now 'local', '%Y' %}, {{ cookiecutter.full_name }}"
 author = "{{ cookiecutter.full_name }}"
+project_slug = {{ cookiecutter.project_slug }}
 
 # The version info for the project you're documenting, acts as replacement
 # for |version| and |release|, also used in various other places throughout
@@ -189,13 +190,13 @@ with open("_static/header.rst", "rt") as fin:
 
 # replace readthedocs link with internal link to this documentation
 lines_mod = [
-    line.replace(f'https://{project}.readthedocs.io', project) for line in lines]
+    line.replace(f'https://{project_slug}.readthedocs.io', project_slug) for line in lines]
 
 # if not found, add this documentation link to the end of the list, so that
 # it is in the doc tree
-contains_project = any(project in line for line in lines_mod)
+contains_project = any(project_slug in line for line in lines_mod)
 if not contains_project:
-    lines_mod.append(f'   {project} <{project}>\n')
+    lines_mod.append(f'   {project} <{project_slug}>\n')
 
 # write the modified header file
 # to the doc\header.rst folder, so that it can be used in the documentation

--- a/{{cookiecutter.project_slug}}/docs/conf.py
+++ b/{{cookiecutter.project_slug}}/docs/conf.py
@@ -58,7 +58,7 @@ master_doc = 'index'
 project = '{{ cookiecutter.project_name }}'
 copyright = "{% now 'local', '%Y' %}, {{ cookiecutter.full_name }}"
 author = "{{ cookiecutter.full_name }}"
-project_slug = {{ cookiecutter.project_slug }}
+project_slug = "{{ cookiecutter.project_slug }}"
 
 # The version info for the project you're documenting, acts as replacement
 # for |version| and |release|, also used in various other places throughout


### PR DESCRIPTION
I went to the tutorial, exept setup on pypi. everthing works as expeced, a few tiny things can be imporved

### Changes proposed in this pull request:

- bug in docs for package names with spaces, fixed by useing the project slug instead of the name in the docs
- small fixes and clarifications in tutorial and promps doc
- add auto generated doc build files to gitignore
- adapt tests
- rename default name to mypackage to prevent errors with _
